### PR TITLE
Fix version handling for major versions besides 1, and update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,19 @@ The api.dartlang.org prepends some structure to the links from dartdoc.
 
 ## Deployment 
 
-1. Download the [Google App Engine SDK for Python][GAE] and add it to your 
-PATH.
+1. Install the [Google Cloud SDK][gcloud].
 
-1. Run `appcfg.py update <folder containing app.yaml>`.
+1. Run `gcloud auth login`
 
-[GAE]: https://developers.google.com/appengine/downloads#Google_App_Engine_SDK_for_Python "Google App Engine SDK for Python"
+1. Run `gcloud config set app/promote_by_default false` to avoid accidentally
+   deploying a test version.
+
+1. Run `gcloud config set project dartlang-api`
+
+1. Run `gcloud app deploy -v name-of-new-version server/app.yaml` and test
+
+1. Run `gcloud app deploy -v name-of-new-version --promote server/app.yaml` to
+   make this version the default
+
+
+[gcloud]: https://cloud.google.com/sdk/downloads

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -2,9 +2,6 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-application: dartlang-api
-version: gcs-new-redirects-path
-
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/server/scripts/redirector.py
+++ b/server/scripts/redirector.py
@@ -108,7 +108,7 @@ class ApiDocs(blobstore_handlers.BlobstoreDownloadHandler):
     if index != -1:
       nums = version_num.split('.')
       release_num = nums[1]
-      if int(release_num) < 15:
+      if nums[0] == '1' and int(release_num) < 15:
         return '%s/%s/%s' % (ApiDocs.GOOGLE_STORAGE_NEW, version_num, postfix)
     return '%s/%s/%s/%s' % (ApiDocs.GOOGLE_STORAGE_NEW, suffix, version_num, postfix)
 
@@ -136,6 +136,8 @@ class ApiDocs(blobstore_handlers.BlobstoreDownloadHandler):
         version_num = self.get_latest_version(channel) 
       postfix = 'index.html'
     path = self.build_gcs_path(version_num, postfix, channel)
+    logging.debug('build_gcs_path("%s", "%s", "%s") -> "%s"'
+                  % (version_num, postfix, channel, path))
     return path
 
   def get_channel(self):


### PR DESCRIPTION
Fixes #65 and updates the README to reflect current practices for updating App Engine apps.

Verified by adding some debug code.  Before the change, debugging code outputs:

```
build_gcs_path("2.0.0-dev.1.0", "index.html", "dev") -> "/dartlang-api-docs/gen-dartdocs/2.0.0-dev.1.0/index.html" (/base/data/home/apps/s~dartlang-api/v2-redirect-bugfix.404291629345281918/scripts/redirector.py:140)
```

After the change:
```
build_gcs_path("2.0.0-dev.1.0", "index.html", "dev") -> "/dartlang-api-docs/gen-dartdocs/dev/2.0.0-dev.1.0/index.html" (/base/data/home/apps/s~dartlang-api/v2-redirect-bugfix.404291682087747046/scripts/redirector.py:140)
```

Test code running at https://v2-redirect-bugfix-dot-dartlang-api.appspot.com.

